### PR TITLE
Added project command to the top level cmake file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(Merely3D)
+project(merely3d)
 
 set (CMAKE_CXX_STANDARD 11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
+project(Merely3D)
+
 set (CMAKE_CXX_STANDARD 11)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/embed_shaders.cmake)


### PR DESCRIPTION
This was necessary, because otherwise including merely3d in another project via  ``add_subdirectory`` doesn't work.